### PR TITLE
fix: align navbar borders and remove orphan separator

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -3,7 +3,6 @@ import { useFrappeAuth } from "frappe-react-sdk"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { CloudUploadIcon, LogoutIcon, UserCircleIcon } from "@hugeicons/core-free-icons"
 import { Button } from "@/components/ui/button"
-import { Separator } from "@/components/ui/separator"
 import { SidebarTrigger } from "@/components/ui/sidebar"
 import { UploadDialog } from "@/components/UploadDialog"
 import { ModeToggle } from "@/components/mode-toggle"
@@ -23,10 +22,6 @@ export function Header() {
     <header className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-background px-4 md:px-6">
       <div className="flex items-center gap-2">
         <SidebarTrigger className="-ml-1" />
-        <Separator
-          orientation="vertical"
-          className="mr-2 hidden md:block data-[orientation=vertical]:h-4"
-        />
       </div>
       <div className="flex items-center gap-3">
         <Button variant="outline" size="sm" onClick={() => setUploadOpen(true)}>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@ export function AppSidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
 
   return (
     <Sidebar>
-      <SidebarHeader className="border-b border-sidebar-border px-4 py-3">
+      <SidebarHeader className="h-14 shrink-0 flex-row items-center border-b border-sidebar-border px-4">
         <span className="text-lg font-bold text-sidebar-foreground">VMS</span>
       </SidebarHeader>
       <SidebarContent>

--- a/vms/api.py
+++ b/vms/api.py
@@ -313,7 +313,12 @@ def rename_asset(asset_name: str, new_file_name: str):
 		file_size=asset.file_size,
 	)
 
-	return {"status": "ok", "asset_name": asset.name, "old_file_name": old_file_name, "new_file_name": new_file_name}
+	return {
+		"status": "ok",
+		"asset_name": asset.name,
+		"old_file_name": old_file_name,
+		"new_file_name": new_file_name,
+	}
 
 
 @frappe.whitelist()

--- a/vms/public/frontend/index.html
+++ b/vms/public/frontend/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/assets/vms/frontend/vms-logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BWH VMS</title>
-    <script type="module" crossorigin src="/assets/vms/frontend/assets/index-PNh42eIs.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/vms/frontend/assets/index-CqKX5av-.css">
+    <script type="module" crossorigin src="/assets/vms/frontend/assets/index-Du5eT9YR.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/vms/frontend/assets/index-VQ8vvVbA.css">
   </head>
   <body>
     <div id="root"></div>

--- a/vms/www/vms.html
+++ b/vms/www/vms.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/assets/vms/frontend/vms-logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BWH VMS</title>
-    <script type="module" crossorigin src="/assets/vms/frontend/assets/index-PNh42eIs.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/vms/frontend/assets/index-CqKX5av-.css">
+    <script type="module" crossorigin src="/assets/vms/frontend/assets/index-Du5eT9YR.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/vms/frontend/assets/index-VQ8vvVbA.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Removed the orphan vertical separator that appeared next to the sidebar collapse icon with no adjacent content
- Set sidebar header to `h-14` to match the main header height, ensuring their bottom borders align perfectly

Fixes #4

## Test plan
- [x] Verify orphan vertical divider is removed
- [x] Verify sidebar header and main header bottom borders are aligned
- [x] Verify collapsed sidebar state works correctly
- [x] Build succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)