### PR TITLE
fix: make calendar picker icon visible in dark mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -127,3 +127,10 @@
     @apply font-sans;
     }
 }
+
+/* Fix native date/time input icons invisible in dark mode */
+.dark input[type="date"]::-webkit-calendar-picker-indicator,
+.dark input[type="time"]::-webkit-calendar-picker-indicator,
+.dark input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}

--- a/vms/public/frontend/index.html
+++ b/vms/public/frontend/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/assets/vms/frontend/vms-logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BWH VMS</title>
-    <script type="module" crossorigin src="/assets/vms/frontend/assets/index-DHtWBIWK.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/vms/frontend/assets/index-VQ8vvVbA.css">
+    <script type="module" crossorigin src="/assets/vms/frontend/assets/index-BOMuJqLn.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/vms/frontend/assets/index-BsnRczmW.css">
   </head>
   <body>
     <div id="root"></div>

--- a/vms/www/vms.html
+++ b/vms/www/vms.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/assets/vms/frontend/vms-logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BWH VMS</title>
-    <script type="module" crossorigin src="/assets/vms/frontend/assets/index-DHtWBIWK.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/vms/frontend/assets/index-VQ8vvVbA.css">
+    <script type="module" crossorigin src="/assets/vms/frontend/assets/index-BOMuJqLn.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/vms/frontend/assets/index-BsnRczmW.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Adds CSS `filter: invert(1)` to native date/time input calendar picker indicators in dark mode
- Fixes the calendar icon being invisible (black on dark background) in the "Create Project" dialog and any other date inputs

## Test plan
- [x] Open Projects page → switch to dark mode → click "New Project"
- [x] Verify the calendar icon in the "Due Date" field is now visible (white on dark)
- [x] Tested with agent-browser, screenshot confirms fix

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)