### PR TITLE
feat(upload): paste files from the clipboard to upload

### DIFF
--- a/e2e/tests/paste-upload.spec.ts
+++ b/e2e/tests/paste-upload.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, Page } from "@playwright/test";
+import { createTestProject, cleanupTestProjects } from "../helpers";
+import { dialog } from "../helpers/ui";
+import { Shell } from "../pages";
+
+// A 1x1 PNG — the smallest thing the clipboard can hand us that the backend's
+// allowed_extensions accepts.
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+/**
+ * Fire the same `paste` event Chrome fires for Mod+V / Mod+Shift+V, with a
+ * file on the clipboard. `selector` targets the element the paste lands on;
+ * without it the event goes to the document, as it does when nothing is focused.
+ */
+async function pasteFile(
+  page: Page,
+  options: {
+    fileName: string;
+    base64: string;
+    type: string;
+    selector?: string;
+  },
+) {
+  await page.evaluate(({ fileName, base64, type, selector }) => {
+    const bytes = Uint8Array.from(atob(base64), (char) => char.charCodeAt(0));
+    const data = new DataTransfer();
+    data.items.add(new File([bytes], fileName, { type }));
+    const target = selector ? document.querySelector(selector) : document;
+    target?.dispatchEvent(
+      new ClipboardEvent("paste", {
+        clipboardData: data,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  }, options);
+}
+
+test.describe("Paste to upload", () => {
+  let projectName: string;
+
+  test.beforeAll(async ({ request }) => {
+    const project = await createTestProject(request, {
+      project_name: `E2E Paste Project ${Date.now()}`,
+    });
+    projectName = project.name;
+  });
+
+  test.afterAll(async ({ request }) => {
+    await cleanupTestProjects(request, "E2E Paste Project");
+  });
+
+  test("opens the upload dialog with the pasted file queued", async ({
+    page,
+  }) => {
+    const shell = new Shell(page);
+    await shell.goto(`/vms/projects/${projectName}`);
+
+    const fileName = `pasted-${Date.now()}.png`;
+    await pasteFile(page, {
+      fileName,
+      base64: PNG_BASE64,
+      type: "image/png",
+    });
+
+    const uploadDialog = dialog(page, "Upload Assets");
+    await expect(uploadDialog).toBeVisible({ timeout: 5000 });
+    await expect(uploadDialog.getByText(fileName)).toBeVisible();
+
+    // The paste queues straight into the upload, no extra click.
+    await expect(uploadDialog.getByText("1 uploaded")).toBeVisible({
+      timeout: 30000,
+    });
+  });
+
+  test("leaves a paste inside a text field alone", async ({ page }) => {
+    const shell = new Shell(page);
+    await shell.goto(`/vms/projects/${projectName}`);
+
+    const search = page.getByPlaceholder("Search");
+    await expect(search.first()).toBeVisible({ timeout: 10000 });
+    await search.first().click();
+
+    await pasteFile(page, {
+      fileName: "ignored.png",
+      base64: PNG_BASE64,
+      type: "image/png",
+      selector: "input[placeholder='Search']",
+    });
+
+    await expect(dialog(page, "Upload Assets")).not.toBeVisible();
+  });
+});

--- a/frontend/src/components/shell/AppShell.vue
+++ b/frontend/src/components/shell/AppShell.vue
@@ -43,6 +43,7 @@ import UploadDialog from '@/components/upload/UploadDialog.vue'
 import UploadQueuePanel from '@/components/upload/UploadQueuePanel.vue'
 import { useBreakpoint } from '@/composables/useBreakpoint'
 import { useOverlays, type SettingsTab } from '@/composables/useOverlays'
+import { usePasteUpload } from '@/composables/usePasteUpload'
 import { useSession } from '@/composables/useSession'
 
 usePageMeta(() => ({ title: 'VMS' }))
@@ -52,6 +53,9 @@ const router = useRouter()
 const { isDesktop } = useBreakpoint()
 const { ready } = useSession()
 const { commandPaletteOpen, shortcutsOpen, openSettings, openUpload } = useOverlays()
+
+// Mod+V / Mod+Shift+V anywhere outside a text field uploads the clipboard.
+usePasteUpload()
 
 // Pages that own their scroll (the audit log) render a fixed-height body with
 // their own ScrollArea, so the shell must not page-scroll around them.

--- a/frontend/src/components/upload/UploadDialog.vue
+++ b/frontend/src/components/upload/UploadDialog.vue
@@ -156,6 +156,9 @@ watch(
 		selectedFolder.value = context.folder ?? ''
 		category.value = context.category ?? 'Footage'
 		versionQueued.value = false
+		// Pasted files arrive with the context, so they queue without a trip
+		// through the drop area.
+		if (context.files?.length) queueFiles(context.files)
 	},
 	{ immediate: true },
 )

--- a/frontend/src/composables/usePasteUpload.ts
+++ b/frontend/src/composables/usePasteUpload.ts
@@ -1,0 +1,74 @@
+/**
+ * Paste-to-upload.
+ *
+ * `Mod+V` and `Mod+Shift+V` fire the same `paste` event, so one document-level
+ * listener covers both. A screenshot arrives as an image file; a file copied in
+ * Finder/Explorer arrives as that file. Pastes inside a text field are left
+ * alone — normal paste keeps working.
+ *
+ * Pages register where a paste should land with `useUploadTarget()`, so pasting
+ * on a project page uploads into that project and folder and refreshes it.
+ */
+import { onMounted, onUnmounted, toValue, type MaybeRefOrGetter } from 'vue'
+import { toast } from 'frappe-ui'
+
+import { useOverlays } from '@/composables/useOverlays'
+import type { UploadContext } from '@/types'
+
+// Mirrors UploadDropArea's accept list: types the browser labels, plus the
+// video containers it has no MIME type for.
+const EXTRA_EXTENSIONS = ['mkv', 'avi', 'm4v']
+
+type ContextGetter = () => UploadContext
+
+let currentTarget: ContextGetter | null = null
+
+/**
+ * Register the upload context a paste on this page should use. The page that
+ * mounted last owns it; unmounting hands it back.
+ */
+export function useUploadTarget(context: MaybeRefOrGetter<UploadContext>): void {
+	const getter: ContextGetter = () => toValue(context)
+	onMounted(() => {
+		currentTarget = getter
+	})
+	onUnmounted(() => {
+		if (currentTarget === getter) currentTarget = null
+	})
+}
+
+/** Mounted once by `AppShell`. */
+export function usePasteUpload(): void {
+	const { openUpload } = useOverlays()
+
+	function handlePaste(event: ClipboardEvent): void {
+		if (isEditable(event.target)) return
+
+		const pasted = Array.from(event.clipboardData?.files ?? [])
+		if (pasted.length === 0) return
+
+		event.preventDefault()
+		const files = pasted.filter(isUploadable)
+		if (files.length === 0) {
+			toast.error('Only video, audio, or image files can be pasted')
+			return
+		}
+
+		openUpload({ ...(currentTarget?.() ?? {}), files })
+	}
+
+	onMounted(() => document.addEventListener('paste', handlePaste))
+	onUnmounted(() => document.removeEventListener('paste', handlePaste))
+}
+
+function isUploadable(file: File): boolean {
+	if (/^(video|audio|image)\//.test(file.type)) return true
+	const extension = file.name.split('.').pop()?.toLowerCase() ?? ''
+	return EXTRA_EXTENSIONS.includes(extension)
+}
+
+function isEditable(target: EventTarget | null): boolean {
+	if (!(target instanceof HTMLElement)) return false
+	if (target.isContentEditable) return true
+	return ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)
+}

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -185,6 +185,7 @@ import type { Asset, Project, ProjectStatus } from '@/types'
 import { formatBytes } from '@/lib/format'
 import { assetStatusTheme, type BadgeTheme } from '@/lib/status'
 import { useOverlays } from '@/composables/useOverlays'
+import { useUploadTarget } from '@/composables/usePasteUpload'
 import EmptyState from '@/components/common/EmptyState.vue'
 import RelativeTime from '@/components/common/RelativeTime.vue'
 import FileTypeIcon from '@/components/common/FileTypeIcon.vue'
@@ -194,6 +195,7 @@ import SkeletonCards from '@/components/common/SkeletonCards.vue'
 usePageMeta(() => ({ title: 'Home · VMS' }))
 
 const { openUpload, createProjectOpen } = useOverlays()
+useUploadTarget(() => ({ onDone: () => void assets.reload() }))
 
 type RecentProject = Pick<Project, 'name' | 'project_name' | 'status' | 'modified'>
 type RecentAsset = Pick<

--- a/frontend/src/pages/InboxPage.vue
+++ b/frontend/src/pages/InboxPage.vue
@@ -204,6 +204,7 @@ import { formatBytes, serverMessage } from '@/lib/format'
 import { assetStatusTheme } from '@/lib/status'
 import { useDownload } from '@/composables/useDownload'
 import { useOverlays } from '@/composables/useOverlays'
+import { useUploadTarget } from '@/composables/usePasteUpload'
 import AssetActions from '@/components/assets/AssetActions.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import RelativeTime from '@/components/common/RelativeTime.vue'
@@ -216,6 +217,7 @@ const PAGE_SIZE = 20
 const COLUMNS = ['minmax(12rem,1fr)', '9rem', '6rem', '5rem', '7rem', '2.5rem']
 
 const { openUpload } = useOverlays()
+useUploadTarget(() => ({ onDone: reload }))
 const { downloadMany, isDownloading } = useDownload()
 
 const categoryOptions = ASSET_CATEGORIES.map((c) => ({ label: c, value: c }))

--- a/frontend/src/pages/ProjectDetailPage.vue
+++ b/frontend/src/pages/ProjectDetailPage.vue
@@ -289,6 +289,7 @@ import { serverMessage } from '@/lib/format'
 import ShareProjectPanel from '@/components/projects/ShareProjectPanel.vue'
 import { useProjectBrowser } from '@/components/projects/useProjectBrowser'
 import { useProjectPageActions } from '@/components/projects/useProjectPageActions'
+import { useUploadTarget } from '@/composables/usePasteUpload'
 import SkeletonLines from '@/components/common/SkeletonLines.vue'
 import SkeletonCards from '@/components/common/SkeletonCards.vue'
 
@@ -301,6 +302,12 @@ const browser = useProjectBrowser(
 	() => props.projectId,
 	() => props.folderId,
 )
+// A paste on this page lands in the project and folder being browsed.
+useUploadTarget(() => ({
+	project: props.projectId,
+	folder: props.folderId,
+	onDone: () => void browser.reloadAssets(),
+}))
 const {
 	project,
 	assetsCall,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -274,6 +274,8 @@ export interface UploadContext {
 	category?: string
 	/** Overrides file.name as the stored file name. */
 	fileName?: string
+	/** Files the dialog queues as soon as it opens (paste). */
+	files?: File[]
 }
 
 export type UploadStatus = 'queued' | 'uploading' | 'confirming' | 'done' | 'error' | 'cancelled'


### PR DESCRIPTION
## Why?

Getting a screenshot or a file into VMS meant saving it to disk first, then opening the upload dialog and browsing to it. The clipboard already holds the file.

## What?

`Cmd+V` / `Cmd+Shift+V` anywhere outside a text field opens the upload dialog with the clipboard's files already queued and uploading.

- Context-aware: on a project or folder page it uploads into that project and folder and refreshes it; Inbox and Dashboard refresh too.
- Non-media files on the clipboard get a toast, not an upload.
- Paste inside inputs, textareas and the comment editor is untouched.
- Video works whenever the OS puts a real file on the clipboard (copying an `.mp4` in Finder). Copying a video from a web page only puts a URL, so nothing pastes.

## How?

`usePasteUpload()` is mounted once in `AppShell` and listens for `paste` on the document — the same event fires for both key combos. Pages register their upload context with `useUploadTarget()`, and `UploadContext.files` lets the dialog queue what it was opened with.

New e2e spec `e2e/tests/paste-upload.spec.ts` covers both the paste and the text-field case, asserting a real upload completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wSnwPUCUiLDAGtWGNC3sh