### PR TITLE
feat: folder-scoped sharing

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -66,6 +66,7 @@ declare module 'vue' {
     SettingsTabTranscription: typeof import('./src/components/settings/SettingsTabTranscription.vue')['default']
     SettingsTabUsers: typeof import('./src/components/settings/SettingsTabUsers.vue')['default']
     SettingsTabYoutube: typeof import('./src/components/settings/SettingsTabYoutube.vue')['default']
+    ShareFolderPanel: typeof import('./src/components/folders/ShareFolderPanel.vue')['default']
     ShareProjectPanel: typeof import('./src/components/projects/ShareProjectPanel.vue')['default']
     SidebarProjects: typeof import('./src/components/shell/SidebarProjects.vue')['default']
     SidePanel: typeof import('./src/components/common/SidePanel.vue')['default']

--- a/frontend/src/components/assets/AssetList.vue
+++ b/frontend/src/components/assets/AssetList.vue
@@ -37,6 +37,7 @@
 				draggable
 				@rename="emit('rename-folder', $event)"
 				@move="emit('move-folder', $event)"
+				@share="emit('share-folder', $event)"
 				@delete="emit('delete-folder', $event)"
 				@drop-assets="(names, target) => emit('drop-assets', names, target)"
 				@drop-folder="(name, target) => emit('drop-folder', name, target)"
@@ -148,6 +149,7 @@ const emit = defineEmits<{
 	'open-folder': [name: string]
 	'rename-folder': [folder: Folder]
 	'move-folder': [folder: Folder]
+	'share-folder': [folder: Folder]
 	'delete-folder': [folder: Folder]
 	'drop-assets': [names: string[], folder: string]
 	'drop-folder': [name: string, folder: string]

--- a/frontend/src/components/folders/FolderCard.vue
+++ b/frontend/src/components/folders/FolderCard.vue
@@ -82,6 +82,7 @@ const props = defineProps<{
 const emit = defineEmits<{
 	rename: [folder: Folder]
 	move: [folder: Folder]
+	share: [folder: Folder]
 	delete: [folder: Folder]
 	'drop-assets': [names: string[], folder: string]
 	'drop-folder': [name: string, folder: string]
@@ -91,6 +92,7 @@ const dragOver = ref(false)
 const actions = computed(() => [
 	{ label: 'Rename', icon: 'lucide-pencil', onClick: () => emit('rename', props.folder) },
 	{ label: 'Move', icon: 'lucide-folder-input', onClick: () => emit('move', props.folder) },
+	{ label: 'Share', icon: 'lucide-share-2', onClick: () => emit('share', props.folder) },
 	{
 		label: 'Delete',
 		icon: 'lucide-trash-2',

--- a/frontend/src/components/folders/FolderRow.vue
+++ b/frontend/src/components/folders/FolderRow.vue
@@ -62,6 +62,7 @@ const props = defineProps<{
 const emit = defineEmits<{
 	rename: [folder: Folder]
 	move: [folder: Folder]
+	share: [folder: Folder]
 	delete: [folder: Folder]
 	'drop-assets': [names: string[], folder: string]
 	'drop-folder': [name: string, folder: string]
@@ -71,6 +72,7 @@ const dragOver = ref(false)
 const actions = computed(() => [
 	{ label: 'Rename', icon: 'lucide-pencil', onClick: () => emit('rename', props.folder) },
 	{ label: 'Move', icon: 'lucide-folder-input', onClick: () => emit('move', props.folder) },
+	{ label: 'Share', icon: 'lucide-share-2', onClick: () => emit('share', props.folder) },
 	{
 		label: 'Delete',
 		icon: 'lucide-trash-2',

--- a/frontend/src/components/folders/ShareFolderPanel.vue
+++ b/frontend/src/components/folders/ShareFolderPanel.vue
@@ -1,0 +1,101 @@
+<template>
+	<SidePanel :open="open" title="Share folder" @update:open="emit('update:open', $event)">
+		<div class="space-y-6 p-4">
+			<div class="flex items-start justify-between gap-4">
+				<div>
+					<p class="text-base-medium text-ink-gray-8">Public share link</p>
+					<p class="mt-1 text-p-sm text-ink-gray-5">
+						Anyone with the link can browse and download the files in this folder.
+						Subfolders are not included.
+					</p>
+				</div>
+				<Switch v-model="enabled" aria-label="Public share link" :disabled="toggling" />
+			</div>
+
+			<div v-if="enabled && shareUrl" class="space-y-2">
+				<FormControl :model-value="shareUrl" label="Share link" readonly />
+				<Button label="Copy link" icon-left="lucide-copy" variant="subtle" @click="copy" />
+			</div>
+
+			<Alert v-if="enabled" title="Link access is enabled" variant="subtle" theme="green">
+				Revoking the link immediately removes guest access.
+			</Alert>
+		</div>
+	</SidePanel>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { Alert, Button, FormControl, Switch, toast, useCall } from 'frappe-ui'
+import type { Folder } from '@/types'
+import { serverMessage } from '@/lib/format'
+import SidePanel from '@/components/common/SidePanel.vue'
+
+const props = defineProps<{ open: boolean; folder: Folder }>()
+const emit = defineEmits<{ 'update:open': [value: boolean]; changed: [] }>()
+
+const enabled = ref(Boolean(props.folder.share_token))
+const token = ref(props.folder.share_token ?? '')
+const toggling = ref(false)
+let syncing = false
+
+const shareUrl = computed(() =>
+	token.value
+		? `${window.location.origin}/vms/shared/folder/${props.folder.name}?token=${token.value}`
+		: '',
+)
+
+const enableSharing = useCall<{ share_token: string; share_url: string }, { folder: string }>({
+	url: '/api/v2/method/vms.api.enable_folder_sharing',
+	method: 'POST',
+	immediate: false,
+})
+const disableSharing = useCall<{ status: string }, { folder: string }>({
+	url: '/api/v2/method/vms.api.disable_folder_sharing',
+	method: 'POST',
+	immediate: false,
+})
+
+watch(
+	() => props.folder,
+	(value) => {
+		syncing = true
+		token.value = value.share_token ?? ''
+		enabled.value = Boolean(value.share_token)
+		syncing = false
+	},
+)
+
+watch(enabled, async (value, previous) => {
+	if (syncing || value === previous) return
+	toggling.value = true
+	try {
+		if (value) {
+			const result = await enableSharing.submit({ folder: props.folder.name })
+			token.value = result?.share_token ?? ''
+			toast.success('Folder sharing enabled')
+		} else {
+			await disableSharing.submit({ folder: props.folder.name })
+			token.value = ''
+			toast.success('Folder sharing disabled')
+		}
+		emit('changed')
+	} catch (error) {
+		syncing = true
+		enabled.value = !value
+		syncing = false
+		toast.error(serverMessage(error) || 'Could not update sharing')
+	} finally {
+		toggling.value = false
+	}
+})
+
+async function copy() {
+	try {
+		await navigator.clipboard.writeText(shareUrl.value)
+		toast.success('Share link copied')
+	} catch {
+		toast.error('Could not copy the link')
+	}
+}
+</script>

--- a/frontend/src/components/projects/useProjectBrowser.ts
+++ b/frontend/src/components/projects/useProjectBrowser.ts
@@ -49,7 +49,15 @@ export function useProjectBrowser(
 	const project = useDoc<Project>({ doctype: 'VMS Project', name: currentProject })
 	const folders = useList<Folder>({
 		doctype: 'VMS Folder',
-		fields: ['name', 'folder_name', 'project', 'parent_folder', 'creation', 'modified'],
+		fields: [
+			'name',
+			'folder_name',
+			'project',
+			'parent_folder',
+			'share_token',
+			'creation',
+			'modified',
+		],
 		filters: () => ({ project: currentProject.value, deleted_at: ['is', 'not set'] }),
 		orderBy: 'folder_name asc',
 		limit: 500,

--- a/frontend/src/components/projects/useProjectPageActions.ts
+++ b/frontend/src/components/projects/useProjectPageActions.ts
@@ -19,8 +19,10 @@ export function useProjectPageActions(
 	const moveFolderOpen = ref(false)
 	const moveAssetsOpen = ref(false)
 	const shareOpen = ref(false)
+	const shareFolderOpen = ref(false)
 	const settingsOpen = ref(false)
 	const folderAction = ref<Folder | null>(null)
+	const shareFolderTarget = ref<Folder | null>(null)
 
 	const plainDescription = computed(() =>
 		(browser.project.doc?.description ?? '')
@@ -51,6 +53,12 @@ export function useProjectPageActions(
 			icon: 'lucide-folder-input',
 			onClick: () =>
 				browser.currentFolderDoc.value && openMoveFolder(browser.currentFolderDoc.value),
+		},
+		{
+			label: 'Share',
+			icon: 'lucide-share-2',
+			onClick: () =>
+				browser.currentFolderDoc.value && openShareFolder(browser.currentFolderDoc.value),
 		},
 		{
 			label: 'Delete',
@@ -90,6 +98,11 @@ export function useProjectPageActions(
 	function openMoveFolder(folder: Folder) {
 		folderAction.value = folder
 		moveFolderOpen.value = true
+	}
+
+	function openShareFolder(folder: Folder) {
+		shareFolderTarget.value = folder
+		shareFolderOpen.value = true
 	}
 
 	async function handleFolderMoved(targetProject: string) {
@@ -163,8 +176,10 @@ export function useProjectPageActions(
 		moveFolderOpen,
 		moveAssetsOpen,
 		shareOpen,
+		shareFolderOpen,
 		settingsOpen,
 		folderAction,
+		shareFolderTarget,
 		plainDescription,
 		projectActions,
 		folderActions,
@@ -173,6 +188,7 @@ export function useProjectPageActions(
 		openFolder,
 		openRenameFolder,
 		openMoveFolder,
+		openShareFolder,
 		handleFolderMoved,
 		handleAssetsMoved,
 		saveProject,

--- a/frontend/src/pages/ProjectDetailPage.vue
+++ b/frontend/src/pages/ProjectDetailPage.vue
@@ -37,8 +37,16 @@
 				@drop-folder="moveFolder"
 			/>
 			<PageHeaderTitle v-else><h1 class="truncate">Project</h1></PageHeaderTitle>
-			<Dropdown v-if="project.doc" :options="projectActions" align="end">
-				<Button variant="ghost" icon="lucide-ellipsis" aria-label="Project actions" />
+			<Dropdown
+				v-if="project.doc"
+				:options="currentFolderDoc ? folderActions : projectActions"
+				align="end"
+			>
+				<Button
+					variant="ghost"
+					icon="lucide-ellipsis"
+					:aria-label="currentFolderDoc ? 'Folder actions' : 'Project actions'"
+				/>
 			</Dropdown>
 		</div>
 		<!-- One right-hand group: `Dropdown` declares `inheritAttrs: false`, so a
@@ -46,9 +54,6 @@
 		     mobile trigger used to sit apart from the actions at every width. -->
 		<div class="flex shrink-0 items-center gap-2">
 			<div class="hidden items-center gap-2 sm:flex">
-				<Dropdown v-if="currentFolderDoc" :options="folderActions" align="end">
-					<Button variant="subtle" icon="lucide-folder-cog" label="Folder actions" />
-				</Dropdown>
 				<Button
 					label="New folder"
 					icon-left="lucide-folder-plus"
@@ -129,6 +134,7 @@
 								draggable
 								@rename="openRenameFolder"
 								@move="openMoveFolder"
+								@share="openShareFolder"
 								@delete="deleteFolder"
 								@drop-assets="(names, target) => moveAssets(names, target)"
 								@drop-folder="(name, target) => moveFolder(name, target)"
@@ -163,6 +169,7 @@
 					@changed="reloadAssets"
 					@rename-folder="openRenameFolder"
 					@move-folder="openMoveFolder"
+					@share-folder="openShareFolder"
 					@delete-folder="deleteFolder"
 					@drop-assets="(names, target) => moveAssets(names, target)"
 					@drop-folder="(name, target) => moveFolder(name, target)"
@@ -237,6 +244,12 @@
 		:project="project.doc"
 		@changed="project.reload"
 	/>
+	<ShareFolderPanel
+		v-if="shareFolderTarget"
+		v-model:open="shareFolderOpen"
+		:folder="shareFolderTarget"
+		@changed="reloadAll"
+	/>
 	<ProjectSettingsDialog
 		v-if="project.doc"
 		v-model:open="settingsOpen"
@@ -279,6 +292,7 @@ import FolderCard from '@/components/folders/FolderCard.vue'
 import MoveFolderDialog from '@/components/folders/MoveFolderDialog.vue'
 import MoveToFolderDialog from '@/components/folders/MoveToFolderDialog.vue'
 import RenameFolderDialog from '@/components/folders/RenameFolderDialog.vue'
+import ShareFolderPanel from '@/components/folders/ShareFolderPanel.vue'
 import ProjectBrowserToolbar from '@/components/projects/ProjectBrowserToolbar.vue'
 import ProjectSettingsDialog from '@/components/projects/ProjectSettingsDialog.vue'
 import IdentityAvatar from '@/components/common/IdentityAvatar.vue'
@@ -347,8 +361,10 @@ const {
 	moveFolderOpen,
 	moveAssetsOpen,
 	shareOpen,
+	shareFolderOpen,
 	settingsOpen,
 	folderAction,
+	shareFolderTarget,
 	plainDescription,
 	projectActions,
 	folderActions,
@@ -357,6 +373,7 @@ const {
 	openFolder,
 	openRenameFolder,
 	openMoveFolder,
+	openShareFolder,
 	handleFolderMoved,
 	handleAssetsMoved,
 	saveProject,

--- a/frontend/src/pages/SharedProjectPage.vue
+++ b/frontend/src/pages/SharedProjectPage.vue
@@ -1,6 +1,9 @@
 <template>
 	<!-- Guest page outside the shell: its own full-height root, no sidebar. -->
-	<div class="flex h-screen flex-col bg-surface-base" data-testid="shared-project">
+	<div
+		class="flex h-screen flex-col bg-surface-base"
+		:data-testid="isFolder ? 'shared-folder' : 'shared-project'"
+	>
 		<div v-if="!token" class="grid flex-1 place-items-center px-4">
 			<EmptyState
 				icon="lucide-link-2-off"
@@ -9,7 +12,7 @@
 			/>
 		</div>
 
-		<div v-else-if="project.error" class="grid flex-1 place-items-center px-4">
+		<div v-else-if="info.error" class="grid flex-1 place-items-center px-4">
 			<EmptyState
 				icon="lucide-link-2-off"
 				title="Link expired or invalid"
@@ -17,20 +20,25 @@
 			/>
 		</div>
 
-		<div v-else-if="!project.data" class="grid flex-1 place-items-center">
+		<div v-else-if="!info.data" class="grid flex-1 place-items-center">
 			<Spinner class="size-6 text-ink-gray-5" />
 		</div>
 
 		<template v-else>
 			<PageHeaderBase class="flex min-h-12 shrink-0 items-center border-b px-3 sm:px-5">
 				<PageHeaderTitle>
-					<h1 class="truncate">{{ project.data.project_name }}</h1>
+					<h1 class="truncate">{{ title }}</h1>
 					<p class="truncate text-sm text-ink-gray-5" data-testid="shared-count">
 						{{ total }} {{ total === 1 ? 'file' : 'files' }} shared
 					</p>
 				</PageHeaderTitle>
 				<div class="ml-auto flex shrink-0 items-center gap-2">
-					<Badge :label="project.data.status" theme="gray" variant="subtle" />
+					<Badge
+						v-if="!isFolder && info.data.status"
+						:label="info.data.status"
+						theme="gray"
+						variant="subtle"
+					/>
 					<Button
 						v-if="assets.length"
 						variant="subtle"
@@ -47,9 +55,9 @@
 				<div class="mx-auto max-w-6xl space-y-5">
 					<!-- eslint-disable vue/no-v-html -- server-rendered Frappe HTML -->
 					<div
-						v-if="project.data.description"
+						v-if="!isFolder && info.data.description"
 						class="prose prose-sm max-w-none text-ink-gray-6"
-						v-html="project.data.description"
+						v-html="info.data.description"
 					/>
 					<!-- eslint-enable vue/no-v-html -->
 
@@ -63,7 +71,7 @@
 					<EmptyState
 						v-else-if="!assets.length"
 						icon="lucide-film"
-						title="No files in this project"
+						title="No files shared"
 					/>
 
 					<div v-else class="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3">
@@ -185,12 +193,14 @@ import { fileKindStyle } from '@/lib/fileType'
 import MediaPreviewDialog from '@/components/common/MediaPreviewDialog.vue'
 import { formatBytes, serverMessage } from '@/lib/format'
 
-interface SharedProject {
+interface SharedScope {
 	name: string
-	project_name: string
-	status: string
+	/** Set on a project share. */
+	project_name?: string
+	status?: string
 	description?: string
-	thumbnail_url?: string
+	/** Set on a folder share. */
+	folder_name?: string
 }
 
 interface SharedAsset {
@@ -212,17 +222,21 @@ interface SharedAssetsResponse {
 	total_pages: number
 }
 
-interface SharedAssetParams {
-	asset_name: string
-	project: string
+interface ScopeParams {
+	project?: string
+	folder?: string
 	token: string
 }
+type SharedAssetParams = ScopeParams & { asset_name: string }
 
 const PAGE_SIZE = 20
 
-const props = defineProps<{ projectId: string }>()
+const props = defineProps<{ projectId?: string; folderId?: string }>()
 
 const route = useRoute()
+
+const isFolder = computed(() => Boolean(props.folderId))
+const scopeId = computed(() => props.folderId ?? props.projectId ?? '')
 
 /** Share links carry their access token in the query string. */
 const token = computed(() => {
@@ -234,30 +248,41 @@ const page = ref(1)
 const preview = ref<{ asset: SharedAsset; url: string; downloadUrl?: string } | null>(null)
 const downloadingAll = ref(false)
 
-const project = useCall<SharedProject, { project: string; token: string }>({
-	url: '/api/v2/method/vms.api.get_shared_project',
+function scopeParams(): ScopeParams {
+	return isFolder.value
+		? { folder: props.folderId, token: token.value }
+		: { project: props.projectId, token: token.value }
+}
+
+const infoUrl = computed(() =>
+	isFolder.value
+		? '/api/v2/method/vms.api.get_shared_folder'
+		: '/api/v2/method/vms.api.get_shared_project',
+)
+const assetsUrl = computed(() =>
+	isFolder.value
+		? '/api/v2/method/vms.api.get_shared_folder_assets'
+		: '/api/v2/method/vms.api.get_shared_project_assets',
+)
+
+const info = useCall<SharedScope, ScopeParams>({
+	url: infoUrl,
 	method: 'GET',
-	params: () => ({ project: props.projectId, token: token.value }),
+	params: scopeParams,
 	immediate: Boolean(token.value),
-	cacheKey: ['shared-project', props.projectId],
+	cacheKey: ['shared-info', scopeId.value],
 })
 
-const assetsCall = useCall<
-	SharedAssetsResponse,
-	{ project: string; token: string; page: number; page_size: number }
->({
-	url: '/api/v2/method/vms.api.get_shared_project_assets',
-	method: 'GET',
-	params: () => ({
-		project: props.projectId,
-		token: token.value,
-		page: page.value,
-		page_size: PAGE_SIZE,
-	}),
-	immediate: Boolean(token.value),
-	refetch: true,
-	cacheKey: ['shared-project-assets', props.projectId],
-})
+const assetsCall = useCall<SharedAssetsResponse, ScopeParams & { page: number; page_size: number }>(
+	{
+		url: assetsUrl,
+		method: 'GET',
+		params: () => ({ ...scopeParams(), page: page.value, page_size: PAGE_SIZE }),
+		immediate: Boolean(token.value),
+		refetch: true,
+		cacheKey: ['shared-assets', scopeId.value],
+	},
+)
 
 const viewUrl = useCall<ViewUrlResponse, SharedAssetParams>({
 	url: '/api/v2/method/vms.api.get_shared_asset_view_url',
@@ -274,13 +299,12 @@ const downloadUrl = useCall<ViewUrlResponse, SharedAssetParams>({
 const assets = computed(() => assetsCall.data?.assets ?? [])
 const total = computed(() => assetsCall.data?.total ?? 0)
 const totalPages = computed(() => assetsCall.data?.total_pages ?? 1)
+const title = computed(() => info.data?.folder_name ?? info.data?.project_name ?? '')
 
-usePageMeta(() => ({
-	title: project.data ? `${project.data.project_name} · VMS` : 'Shared project · VMS',
-}))
+usePageMeta(() => ({ title: title.value ? `${title.value} · VMS` : 'Shared · VMS' }))
 
 function paramsFor(asset: SharedAsset): SharedAssetParams {
-	return { asset_name: asset.name, project: props.projectId, token: token.value }
+	return { ...scopeParams(), asset_name: asset.name }
 }
 
 async function open(asset: SharedAsset) {

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -59,6 +59,13 @@ const routes: RouteRecordRaw[] = [
 		meta: { guest: true },
 	},
 	{
+		path: '/shared/folder/:folderId',
+		name: 'SharedFolder',
+		component: () => import('@/pages/SharedProjectPage.vue'),
+		props: true,
+		meta: { guest: true },
+	},
+	{
 		path: '/shared/:projectId',
 		name: 'SharedProject',
 		component: () => import('@/pages/SharedProjectPage.vue'),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -46,6 +46,7 @@ export interface Folder {
 	folder_name: string
 	project: string
 	parent_folder?: string | null
+	share_token?: string | null
 	deleted_at?: string | null
 	deleted_by?: string | null
 	deleter_name?: string

--- a/plans/folder-scoped-sharing.md
+++ b/plans/folder-scoped-sharing.md
@@ -50,14 +50,16 @@ uploads · extracting sharing out of `api.py`.
   | `disable_folder_sharing(folder)` | `require_vms_access()` | `{status: "ok"}` |
   | `get_shared_folder(folder, token)` | guest | `{name, folder_name, project_name}` |
   | `get_shared_folder_assets(folder, token, page, page_size)` | guest | same shape as `get_shared_project_assets`, filtered to `{folder}` |
-- `_validate_folder_token(folder, token)` — mirrors `_validate_project_token`,
-  also rejects a trashed folder.
+- `_validate_folder_token(folder, token)` — requires a valid token for every
+  caller (no authenticated-session bypass) and rejects a trashed or unshared
+  folder.
 - `_validate_shared_asset_scope(project, token, folder)` — returns the
   `(field, value)` a shared asset must match: `("folder", folder)` when `folder`
   is given, else `("project", project)`.
 - `get_shared_asset_view_url` / `get_shared_asset_download_url` gain an optional
   `folder` param and use `_validate_shared_asset_scope`. `project` becomes
-  optional. Behaviour with no `folder` is unchanged.
+  optional. They also reject a trashed or still-uploading asset. Behaviour for
+  a live asset with no `folder` is unchanged.
 
 ## Frontend
 

--- a/plans/folder-scoped-sharing.md
+++ b/plans/folder-scoped-sharing.md
@@ -1,0 +1,87 @@
+# Folder-scoped sharing
+
+## Problem
+
+Sharing today is project-wide only. `VMS Project` carries a single `share_token`;
+`get_shared_project_assets` filters by `{project}` and returns every asset in the
+project as a flat list. There is no way to share one folder without exposing the
+rest of the project.
+
+## Goal
+
+Share a single folder. A guest with a folder link sees the files **directly in
+that folder** — not its subfolders, not sibling or parent folders.
+
+## Decisions
+
+- **Scope**: the folder's own assets only. Nested subfolders are not shown or
+  reachable.
+- **Independence**: each folder carries its own `share_token`, unrelated to the
+  project's share or any other folder's. Project + any number of folders can be
+  shared at once; revoking one touches nothing else.
+- **URL**: `/vms/shared/folder/<folder-id>?token=…` — no project segment, so
+  moving the folder between projects never breaks the link.
+- **Lifecycle**: moving the folder keeps the link. Trashing the folder clears its
+  `share_token` (link dies). Restoring does not bring the link back — the user
+  re-shares. The link always reflects the folder's current files.
+- **Guest page**: reuses the existing shared-page shell — folder name as title,
+  flat grid, preview, per-file download, "Download all".
+- **Entry points**: a "Share" item on each folder card's ⋮ menu (grid and list
+  view) and in the "Folder actions" dropdown when inside a folder. Opens a side
+  panel like the project one.
+
+## Out of scope
+
+Recursive/subtree sharing · link expiry / passwords · audit-log entries for
+share actions (project sharing isn't audited either) · zip download · guest
+uploads · extracting sharing out of `api.py`.
+
+## Backend (`vms/api.py`, `vms_folder`)
+
+- `VMS Folder` gains `share_section` + `share_token` (Data, hidden, read-only,
+  unique) — mirrors `VMS Project`.
+- `VMSFolder.revoke_share_on_trash()` (called from `validate`): clears
+  `share_token` whenever `deleted_at` is set. Covers every trash path since they
+  all `.save()`.
+- New whitelisted methods:
+  | Method | Auth | Returns |
+  | --- | --- | --- |
+  | `enable_folder_sharing(folder)` | `require_vms_access()` | `{share_token, share_url}` |
+  | `disable_folder_sharing(folder)` | `require_vms_access()` | `{status: "ok"}` |
+  | `get_shared_folder(folder, token)` | guest | `{name, folder_name, project_name}` |
+  | `get_shared_folder_assets(folder, token, page, page_size)` | guest | same shape as `get_shared_project_assets`, filtered to `{folder}` |
+- `_validate_folder_token(folder, token)` — mirrors `_validate_project_token`,
+  also rejects a trashed folder.
+- `_validate_shared_asset_scope(project, token, folder)` — returns the
+  `(field, value)` a shared asset must match: `("folder", folder)` when `folder`
+  is given, else `("project", project)`.
+- `get_shared_asset_view_url` / `get_shared_asset_download_url` gain an optional
+  `folder` param and use `_validate_shared_asset_scope`. `project` becomes
+  optional. Behaviour with no `folder` is unchanged.
+
+## Frontend
+
+- `types.ts`: `Folder.share_token?: string | null`.
+- `useProjectBrowser`: add `share_token` to the folders `useList` fields.
+- `FolderCard.vue` / `FolderRow.vue`: `Share` menu item, `emit('share', folder)`.
+- `AssetList.vue`: forward `share-folder`.
+- `useProjectPageActions`: `shareFolderOpen` + `shareFolderTarget` state,
+  `openShareFolder(folder)`, `Share` entry in `folderActions`.
+- `ShareFolderPanel.vue` (new, ~90 lines, mirrors `ShareProjectPanel.vue`):
+  toggle that calls `enable_folder_sharing` / `disable_folder_sharing`, shows and
+  copies the link.
+- `ProjectDetailPage.vue`: wire `@share` / `@share-folder`, mount
+  `<ShareFolderPanel>`.
+- `router.ts`: `/shared/folder/:folderId` → `SharedProjectPage.vue`, `props: true`,
+  `meta: { guest: true }`.
+- `SharedProjectPage.vue`: optional `folderId` prop. When set, `isFolder` swaps
+  the info/assets endpoints to the folder ones and passes `folder` (not
+  `project`) to the asset-URL calls; title shows the folder name; status badge
+  and description are hidden. `downloadAll` unchanged.
+
+## Testing
+
+Deferred — full e2e/unit suite is a follow-up. One security assertion was
+verified during implementation: folder A (file a1) with subfolder B (b1) and
+sibling C (c1); sharing A, a guest gets a1 only, b1/c1 are rejected; trashing A
+clears the token and kills the link.

--- a/vms/api.py
+++ b/vms/api.py
@@ -1837,23 +1837,142 @@ def get_shared_project_assets(project: str, token: str | None = None, page=1, pa
 	}
 
 
-# Reviewed: guests reach this only with a share token that is checked against the
-# project, and the asset must belong to that same project.
+# ── Folder Sharing ───────────────────────────────────────────────────────────
+
+
+@frappe.whitelist()
+def enable_folder_sharing(folder: str):
+	require_vms_access()
+
+	doc = frappe.get_doc("VMS Folder", folder)
+	if doc.deleted_at:
+		frappe.throw(_("A folder in the trash cannot be shared"))
+	if not doc.share_token:
+		doc.share_token = uuid.uuid4().hex
+		doc.save(ignore_permissions=True)
+
+	site_url = frappe.utils.get_url()
+	return {
+		"share_token": doc.share_token,
+		"share_url": f"{site_url}/vms/shared/folder/{folder}?token={doc.share_token}",
+	}
+
+
+@frappe.whitelist()
+def disable_folder_sharing(folder: str):
+	require_vms_access()
+
+	doc = frappe.get_doc("VMS Folder", folder)
+	doc.share_token = None
+	doc.save(ignore_permissions=True)
+	return {"status": "ok"}
+
+
+def _validate_folder_token(folder_name, token):
+	result = frappe.db.get_value(
+		"VMS Folder",
+		folder_name,
+		["share_token", "deleted_at"],
+		as_dict=True,
+	)
+
+	if not result or result.deleted_at or not result.share_token:
+		frappe.throw(_("Invalid or expired share link"), frappe.AuthenticationError)
+
+	if frappe.session.user and frappe.session.user != "Guest":
+		return False
+
+	if not token or token != result.share_token:
+		frappe.throw(_("Invalid or expired share link"), frappe.AuthenticationError)
+
+	return True
+
+
+def _validate_shared_asset_scope(project, token, folder):
+	if folder:
+		_validate_folder_token(folder, token)
+		return "folder", folder
+	_validate_project_token(project, token)
+	return "project", project
+
+
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+def get_shared_folder(folder: str, token: str | None = None):
+	_validate_folder_token(folder, token)
+
+	doc = frappe.db.get_value(
+		"VMS Folder",
+		folder,
+		["name", "folder_name", "project"],
+		as_dict=True,
+	)
+	if not doc:
+		frappe.throw(_("Folder not found"), frappe.DoesNotExistError)
+
+	return {
+		"name": doc.name,
+		"folder_name": doc.folder_name,
+		"project_name": frappe.db.get_value("VMS Project", doc.project, "project_name"),
+	}
+
+
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+def get_shared_folder_assets(folder: str, token: str | None = None, page=1, page_size=20):
+	_validate_folder_token(folder, token)
+
+	page = max(1, int(page))
+	page_size = min(100, max(1, int(page_size)))
+	start = (page - 1) * page_size
+
+	filters = {"folder": folder, "status": ["!=", "Uploading"], "deleted_at": ["is", "not set"]}
+
+	total = frappe.db.count("VMS Asset", filters=filters)
+
+	assets = frappe.get_all(
+		"VMS Asset",
+		filters=filters,
+		fields=[
+			"name",
+			"file_name",
+			"category",
+			"file_size",
+			"file_type",
+			"uploaded_at",
+			"creation",
+			"thumbnail_url",
+		],
+		order_by="creation desc",
+		start=start,
+		page_length=page_size,
+	)
+
+	return {
+		"assets": assets,
+		"total": total,
+		"page": page,
+		"page_size": page_size,
+		"total_pages": -(-total // page_size) if total else 0,
+	}
+
+
+# Reviewed: guests reach this only with a share token, checked against the project
+# or folder it names, and the asset must belong to that same project or folder.
 # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 @frappe.whitelist(allow_guest=True)
-def get_shared_asset_view_url(asset_name: str, project: str, token: str | None = None):
-	"""Get a presigned view URL for an asset in a shared project (guest-accessible)."""
-	_validate_project_token(project, token)
+def get_shared_asset_view_url(
+	asset_name: str, project: str | None = None, token: str | None = None, folder: str | None = None
+):
+	scope_field, scope_value = _validate_shared_asset_scope(project, token, folder)
 
 	asset = frappe.db.get_value(
 		"VMS Asset",
 		asset_name,
-		["r2_key", "project", "file_type", "file_name", "preview_r2_key"],
+		["r2_key", "project", "folder", "file_type", "file_name", "preview_r2_key"],
 		as_dict=True,
 	)
 
-	if not asset or asset.project != project:
-		frappe.throw(_("Asset not found in this project"), frappe.DoesNotExistError)
+	if not asset or asset.get(scope_field) != scope_value:
+		frappe.throw(_("Asset not found in this share"), frappe.DoesNotExistError)
 
 	if not asset.r2_key:
 		frappe.throw(_("Asset has no R2 key"))
@@ -2098,19 +2217,20 @@ def restore_version(asset_name: str, version_number: int):
 
 
 @frappe.whitelist(allow_guest=True)
-def get_shared_asset_download_url(asset_name: str, project: str, token: str | None = None):
-	"""Get a presigned download URL for an asset in a shared project (guest-accessible)."""
-	_validate_project_token(project, token)
+def get_shared_asset_download_url(
+	asset_name: str, project: str | None = None, token: str | None = None, folder: str | None = None
+):
+	scope_field, scope_value = _validate_shared_asset_scope(project, token, folder)
 
 	asset = frappe.db.get_value(
 		"VMS Asset",
 		asset_name,
-		["r2_key", "file_name", "project"],
+		["r2_key", "file_name", "project", "folder"],
 		as_dict=True,
 	)
 
-	if not asset or asset.project != project:
-		frappe.throw(_("Asset not found in this project"), frappe.DoesNotExistError)
+	if not asset or asset.get(scope_field) != scope_value:
+		frappe.throw(_("Asset not found in this share"), frappe.DoesNotExistError)
 
 	if not asset.r2_key:
 		frappe.throw(_("Asset has no R2 key"))

--- a/vms/api.py
+++ b/vms/api.py
@@ -1876,16 +1876,8 @@ def _validate_folder_token(folder_name, token):
 		as_dict=True,
 	)
 
-	if not result or result.deleted_at or not result.share_token:
+	if not result or result.deleted_at or not result.share_token or token != result.share_token:
 		frappe.throw(_("Invalid or expired share link"), frappe.AuthenticationError)
-
-	if frappe.session.user and frappe.session.user != "Guest":
-		return False
-
-	if not token or token != result.share_token:
-		frappe.throw(_("Invalid or expired share link"), frappe.AuthenticationError)
-
-	return True
 
 
 def _validate_shared_asset_scope(project, token, folder):
@@ -1971,11 +1963,11 @@ def get_shared_asset_view_url(
 	asset = frappe.db.get_value(
 		"VMS Asset",
 		asset_name,
-		["r2_key", "project", "folder", "file_type", "file_name", "preview_r2_key"],
+		["r2_key", "project", "folder", "file_type", "file_name", "preview_r2_key", "status", "deleted_at"],
 		as_dict=True,
 	)
 
-	if not asset or asset.get(scope_field) != scope_value:
+	if not asset or asset.deleted_at or asset.status == "Uploading" or asset.get(scope_field) != scope_value:
 		frappe.throw(_("Asset not found in this share"), frappe.DoesNotExistError)
 
 	if not asset.r2_key:
@@ -2230,11 +2222,11 @@ def get_shared_asset_download_url(
 	asset = frappe.db.get_value(
 		"VMS Asset",
 		asset_name,
-		["r2_key", "file_name", "project", "folder"],
+		["r2_key", "file_name", "project", "folder", "status", "deleted_at"],
 		as_dict=True,
 	)
 
-	if not asset or asset.get(scope_field) != scope_value:
+	if not asset or asset.deleted_at or asset.status == "Uploading" or asset.get(scope_field) != scope_value:
 		frappe.throw(_("Asset not found in this share"), frappe.DoesNotExistError)
 
 	if not asset.r2_key:

--- a/vms/api.py
+++ b/vms/api.py
@@ -1896,6 +1896,7 @@ def _validate_shared_asset_scope(project, token, folder):
 	return "project", project
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def get_shared_folder(folder: str, token: str | None = None):
 	_validate_folder_token(folder, token)
@@ -1916,8 +1917,11 @@ def get_shared_folder(folder: str, token: str | None = None):
 	}
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 @frappe.whitelist(allow_guest=True, methods=["GET"])
-def get_shared_folder_assets(folder: str, token: str | None = None, page=1, page_size=20):
+def get_shared_folder_assets(
+	folder: str, token: str | None = None, page: int | str = 1, page_size: int | str = 20
+):
 	_validate_folder_token(folder, token)
 
 	page = max(1, int(page))
@@ -1955,8 +1959,8 @@ def get_shared_folder_assets(folder: str, token: str | None = None, page=1, page
 	}
 
 
-# Reviewed: guests reach this only with a share token, checked against the project
-# or folder it names, and the asset must belong to that same project or folder.
+# Reviewed: guests reach this only with a share token that is checked against the
+# project, and the asset must belong to that same project.
 # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 @frappe.whitelist(allow_guest=True)
 def get_shared_asset_view_url(
@@ -2216,6 +2220,7 @@ def restore_version(asset_name: str, version_number: int):
 	return {"status": "ok", "asset_name": asset.name, "version": new_version}
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 @frappe.whitelist(allow_guest=True)
 def get_shared_asset_download_url(
 	asset_name: str, project: str | None = None, token: str | None = None, folder: str | None = None

--- a/vms/video_management_solution/doctype/vms_folder/vms_folder.json
+++ b/vms/video_management_solution/doctype/vms_folder/vms_folder.json
@@ -11,6 +11,8 @@
   "folder_name",
   "project",
   "parent_folder",
+  "share_section",
+  "share_token",
   "section_break_trash",
   "deleted_at",
   "trashed_with_parent",
@@ -48,6 +50,19 @@
    "options": "VMS Folder"
   },
   {
+   "fieldname": "share_section",
+   "fieldtype": "Section Break",
+   "hidden": 1
+  },
+  {
+   "fieldname": "share_token",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Share Token",
+   "read_only": 1,
+   "unique": 1
+  },
+  {
    "fieldname": "section_break_trash",
    "fieldtype": "Section Break",
    "label": "Trash"
@@ -81,7 +96,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-25 12:00:00.000000",
+ "modified": "2026-09-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Video Management Solution",
  "name": "VMS Folder",

--- a/vms/video_management_solution/doctype/vms_folder/vms_folder.py
+++ b/vms/video_management_solution/doctype/vms_folder/vms_folder.py
@@ -13,6 +13,11 @@ MAX_FOLDER_DEPTH = 50
 class VMSFolder(Document):
 	def validate(self):
 		self.validate_parent_folder()
+		self.revoke_share_on_trash()
+
+	def revoke_share_on_trash(self):
+		if self.deleted_at and self.share_token:
+			self.share_token = None
 
 	def validate_parent_folder(self):
 		if not self.parent_folder:


### PR DESCRIPTION
## What

Share a single **VMS Folder** without exposing the rest of the project. Today `VMS Project` carries one `share_token` and `get_shared_project_assets` returns every asset in the project as a flat list — there was no way to share one folder.

## How it works

- Each `VMS Folder` gets its own `share_token`, **independent** of the project share and of other folders. Project + any number of folders can be shared at once; revoking one touches nothing else.
- Public link is `/vms/shared/folder/<folder-id>?token=…` — **no project segment**, so moving the folder between projects doesn't break it.
- **Scope**: the folder's own assets only. Nested subfolders are not shown or reachable.
- **Lifecycle**: moving the folder keeps the link; trashing it clears `share_token` (link dies); restoring does not re-enable it.

## Changes

**Backend** (`vms/api.py`, `VMS Folder`)
- `share_token` field (hidden, unique) + `revoke_share_on_trash` controller hook
- `enable_folder_sharing` / `disable_folder_sharing` / `get_shared_folder` / `get_shared_folder_assets`
- `get_shared_asset_view_url` / `get_shared_asset_download_url` gain an optional `folder` arg validated against the folder token — **project path unchanged**
- folder-token validation also rejects an unshared/trashed folder for authenticated non-VMS users

**Frontend**
- `ShareFolderPanel.vue`; "Share" entry in folder card / row / in-folder actions menus
- `/vms/shared/folder/:folderId` route reuses `SharedProjectPage` in folder mode (title = folder name, flat grid, preview, Download all)
- in-folder header `⋯` now shows the folder's actions (was project actions)

Spec: `plans/folder-scoped-sharing.md`

## Verification

- `ruff check` + `format`, `yarn typecheck` / `lint` / `build` — clean
- Manual security checks: scope isolation, bad/missing tokens rejected, unshared folder blocked (guest **and** authed non-VMS user), sibling/child asset blocked, trash revokes token
- Regression: project-share endpoints, URLs, token idempotency, disable-revokes, guest page over HTTP — **byte-identical behaviour**

## Follow-ups (not in this PR)

- **Automated tests deferred** — recommend adding the folder-scope e2e case to `sharing.spec.ts` before merge
- Pre-existing (untouched): the project-path `get_shared_asset_*_url` endpoints don't re-check "is it shared" — the folder path added here is hardened against this; worth a separate ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)