### PR TITLE
feat: infinite scroll for the project asset grid

### DIFF
--- a/frontend/src/components/assets/AssetCard.vue
+++ b/frontend/src/components/assets/AssetCard.vue
@@ -12,6 +12,8 @@
 				:src="asset.thumbnail_url"
 				alt=""
 				draggable="false"
+				loading="lazy"
+				decoding="async"
 				class="size-full object-cover"
 			/>
 			<div v-else :class="['grid size-full place-items-center', previewStyle.tile]">

--- a/frontend/src/components/common/FileTypeIcon.vue
+++ b/frontend/src/components/common/FileTypeIcon.vue
@@ -7,7 +7,14 @@
 			'grid place-items-center',
 		]"
 	>
-		<img v-if="thumbnailUrl" :src="thumbnailUrl" :alt="alt" class="size-full object-cover" />
+		<img
+			v-if="thumbnailUrl"
+			:src="thumbnailUrl"
+			:alt="alt"
+			loading="lazy"
+			decoding="async"
+			class="size-full object-cover"
+		/>
 		<span v-else :class="[style.icon, iconClass]" aria-hidden="true" />
 	</div>
 </template>

--- a/frontend/src/components/projects/useProjectBrowser.ts
+++ b/frontend/src/components/projects/useProjectBrowser.ts
@@ -39,11 +39,9 @@ export function useProjectBrowser(
 	const category = ref<AssetCategory | ''>('')
 	const tag = ref<string | null>(null)
 	const sort = ref<AssetSort>({ field: 'creation', order: 'desc' })
-	const page = ref(1)
-	const refreshSize = ref<number | null>(null)
-	const assets = ref<Asset[]>([])
-	const total = ref(0)
-	const lastPageFull = ref(true)
+	const limit = ref(PAGE_SIZE)
+	const loadingMore = ref(false)
+	const reachedEnd = ref(false)
 	const selection = ref<string[]>([])
 	const preview = ref<{ asset: Asset; url: string } | null>(null)
 	const view = ref<'grid' | 'list'>(storedView())
@@ -100,28 +98,18 @@ export function useProjectBrowser(
 			category: category.value || undefined,
 			tag: tag.value || undefined,
 			search: search.value || undefined,
-			page: refreshSize.value !== null ? 1 : page.value,
-			page_size: refreshSize.value ?? PAGE_SIZE,
+			page: 1,
+			page_size: limit.value,
 			sort_by: sort.value.field,
 			sort_order: sort.value.order,
 		}),
+		refetch: true,
 		cacheKey: ['project-assets', currentProject.value],
 		staleOnError: true,
-		onSuccess: (data: ProjectAssetsResponse) => {
-			total.value = data.total
-			if (refreshSize.value !== null) {
-				assets.value = data.assets
-				lastPageFull.value = true
-			} else if (page.value === 1) {
-				assets.value = data.assets
-				lastPageFull.value = data.assets.length >= PAGE_SIZE
-			} else {
-				assets.value = [...assets.value, ...data.assets]
-				lastPageFull.value = data.assets.length >= PAGE_SIZE
-			}
-			refreshSize.value = null
-		},
 	})
+
+	const assets = computed(() => assetsCall.data?.assets ?? [])
+	const total = computed(() => assetsCall.data?.total ?? 0)
 	const allFolders = computed(() => folders.data ?? [])
 	const currentFolderDoc = computed(
 		() => allFolders.value.find((folder) => folder.name === currentFolder.value) ?? null,
@@ -155,16 +143,21 @@ export function useProjectBrowser(
 		}
 		return counts
 	})
-	const hasMore = computed(() => assets.value.length < total.value && lastPageFull.value)
-	const loadingMore = computed(
-		() => assetsCall.loading && page.value > 1 && refreshSize.value === null,
-	)
+	const hasMore = computed(() => !reachedEnd.value && assets.value.length < total.value)
 	const hasProcessing = computed(() => assets.value.some((asset) => asset.status === 'Processing'))
 
 	watch(searchInput, (value) => {
 		clearTimeout(debounceTimer)
 		debounceTimer = setTimeout(() => (search.value = value.trim()), 250)
 	})
+	watch(
+		() => assetsCall.loading,
+		(loading) => {
+			if (loading) return
+			loadingMore.value = false
+			reachedEnd.value = assets.value.length < limit.value
+		},
+	)
 	watch([currentProject, currentFolder, category, tag, search, sort], resetList, { deep: true })
 	watch(view, (value) => localStorage.setItem('vms_asset_view', value))
 	watch(hasProcessing, configurePolling, { immediate: true })
@@ -182,13 +175,11 @@ export function useProjectBrowser(
 	})
 
 	async function reloadAssets() {
-		refreshSize.value = Math.max(assets.value.length, PAGE_SIZE)
 		await assetsCall.reload()
 		void countRows.reload()
 	}
 
 	async function reloadAll() {
-		refreshSize.value = Math.max(assets.value.length, PAGE_SIZE)
 		await Promise.all([assetsCall.reload(), folders.reload(), countRows.reload()])
 	}
 
@@ -321,17 +312,16 @@ export function useProjectBrowser(
 	}
 
 	function resetList() {
-		page.value = 1
-		refreshSize.value = null
-		lastPageFull.value = true
+		limit.value = PAGE_SIZE
+		loadingMore.value = false
+		reachedEnd.value = false
 		selection.value = []
-		void assetsCall.reload()
 	}
 
 	function loadMore() {
 		if (assetsCall.loading || !hasMore.value) return
-		page.value += 1
-		void assetsCall.reload()
+		loadingMore.value = true
+		limit.value += PAGE_SIZE
 	}
 
 	return {

--- a/frontend/src/components/projects/useProjectBrowser.ts
+++ b/frontend/src/components/projects/useProjectBrowser.ts
@@ -39,7 +39,11 @@ export function useProjectBrowser(
 	const category = ref<AssetCategory | ''>('')
 	const tag = ref<string | null>(null)
 	const sort = ref<AssetSort>({ field: 'creation', order: 'desc' })
-	const limit = ref(PAGE_SIZE)
+	const page = ref(1)
+	const refreshSize = ref<number | null>(null)
+	const assets = ref<Asset[]>([])
+	const total = ref(0)
+	const lastPageFull = ref(true)
 	const selection = ref<string[]>([])
 	const preview = ref<{ asset: Asset; url: string } | null>(null)
 	const view = ref<'grid' | 'list'>(storedView())
@@ -96,18 +100,28 @@ export function useProjectBrowser(
 			category: category.value || undefined,
 			tag: tag.value || undefined,
 			search: search.value || undefined,
-			page: 1,
-			page_size: limit.value,
+			page: refreshSize.value !== null ? 1 : page.value,
+			page_size: refreshSize.value ?? PAGE_SIZE,
 			sort_by: sort.value.field,
 			sort_order: sort.value.order,
 		}),
-		refetch: true,
 		cacheKey: ['project-assets', currentProject.value],
 		staleOnError: true,
+		onSuccess: (data: ProjectAssetsResponse) => {
+			total.value = data.total
+			if (refreshSize.value !== null) {
+				assets.value = data.assets
+				lastPageFull.value = true
+			} else if (page.value === 1) {
+				assets.value = data.assets
+				lastPageFull.value = data.assets.length >= PAGE_SIZE
+			} else {
+				assets.value = [...assets.value, ...data.assets]
+				lastPageFull.value = data.assets.length >= PAGE_SIZE
+			}
+			refreshSize.value = null
+		},
 	})
-
-	const assets = computed(() => assetsCall.data?.assets ?? [])
-	const total = computed(() => assetsCall.data?.total ?? 0)
 	const allFolders = computed(() => folders.data ?? [])
 	const currentFolderDoc = computed(
 		() => allFolders.value.find((folder) => folder.name === currentFolder.value) ?? null,
@@ -141,7 +155,10 @@ export function useProjectBrowser(
 		}
 		return counts
 	})
-	const hasMore = computed(() => assets.value.length < total.value)
+	const hasMore = computed(() => assets.value.length < total.value && lastPageFull.value)
+	const loadingMore = computed(
+		() => assetsCall.loading && page.value > 1 && refreshSize.value === null,
+	)
 	const hasProcessing = computed(() => assets.value.some((asset) => asset.status === 'Processing'))
 
 	watch(searchInput, (value) => {
@@ -165,11 +182,13 @@ export function useProjectBrowser(
 	})
 
 	async function reloadAssets() {
+		refreshSize.value = Math.max(assets.value.length, PAGE_SIZE)
 		await assetsCall.reload()
 		void countRows.reload()
 	}
 
 	async function reloadAll() {
+		refreshSize.value = Math.max(assets.value.length, PAGE_SIZE)
 		await Promise.all([assetsCall.reload(), folders.reload(), countRows.reload()])
 	}
 
@@ -302,8 +321,17 @@ export function useProjectBrowser(
 	}
 
 	function resetList() {
-		limit.value = PAGE_SIZE
+		page.value = 1
+		refreshSize.value = null
+		lastPageFull.value = true
 		selection.value = []
+		void assetsCall.reload()
+	}
+
+	function loadMore() {
+		if (assetsCall.loading || !hasMore.value) return
+		page.value += 1
+		void assetsCall.reload()
 	}
 
 	return {
@@ -322,6 +350,7 @@ export function useProjectBrowser(
 		folderCounts,
 		selectedAssets,
 		hasMore,
+		loadingMore,
 		searchInput,
 		category,
 		tag,
@@ -333,14 +362,13 @@ export function useProjectBrowser(
 		hasNextPreview,
 		showPreviousPreview: () => stepPreview(-1),
 		showNextPreview: () => stepPreview(1),
-		limit,
 		openAsset,
 		moveAssets,
 		moveFolder,
 		deleteFolder,
 		reloadAssets,
 		reloadAll,
-		loadMore: () => (limit.value += PAGE_SIZE),
+		loadMore,
 	}
 }
 

--- a/frontend/src/composables/useInfiniteScroll.ts
+++ b/frontend/src/composables/useInfiniteScroll.ts
@@ -1,0 +1,40 @@
+import { onScopeDispose, watch, type Ref } from 'vue'
+
+export function useInfiniteScroll(
+	target: Ref<HTMLElement | null>,
+	busy: Ref<boolean>,
+	canLoad: () => boolean,
+	onLoadMore: () => void,
+) {
+	let observer: IntersectionObserver | undefined
+	let intersecting = false
+
+	function maybeLoad() {
+		if (intersecting && !busy.value && canLoad()) onLoadMore()
+	}
+
+	watch(
+		target,
+		(el) => {
+			observer?.disconnect()
+			observer = undefined
+			intersecting = false
+			if (!el) return
+			observer = new IntersectionObserver(
+				(entries) => {
+					intersecting = entries[entries.length - 1]?.isIntersecting ?? false
+					maybeLoad()
+				},
+				{ rootMargin: '600px 0px' },
+			)
+			observer.observe(el)
+		},
+		{ immediate: true },
+	)
+
+	watch(busy, (now, before) => {
+		if (before && !now) maybeLoad()
+	})
+
+	onScopeDispose(() => observer?.disconnect())
+}

--- a/frontend/src/pages/ProjectDetailPage.vue
+++ b/frontend/src/pages/ProjectDetailPage.vue
@@ -174,13 +174,9 @@
 					@drop-assets="(names, target) => moveAssets(names, target)"
 					@drop-folder="(name, target) => moveFolder(name, target)"
 				/>
-				<div v-if="hasMore" class="flex justify-center pt-6">
-					<Button
-						label="Load more"
-						variant="ghost"
-						:loading="assetsCall.loading"
-						@click="loadMore"
-					/>
+				<div v-if="hasMore" ref="sentinel" class="pt-3">
+					<SkeletonCards v-if="loadingMore && view === 'grid'" :count="4" media />
+					<SkeletonLines v-else-if="loadingMore" :lines="3" />
 				</div>
 			</template>
 			<EmptyState
@@ -271,7 +267,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import {
 	Button,
 	Dropdown,
@@ -303,6 +299,7 @@ import { serverMessage } from '@/lib/format'
 import ShareProjectPanel from '@/components/projects/ShareProjectPanel.vue'
 import { useProjectBrowser } from '@/components/projects/useProjectBrowser'
 import { useProjectPageActions } from '@/components/projects/useProjectPageActions'
+import { useInfiniteScroll } from '@/composables/useInfiniteScroll'
 import { useUploadTarget } from '@/composables/usePasteUpload'
 import SkeletonLines from '@/components/common/SkeletonLines.vue'
 import SkeletonCards from '@/components/common/SkeletonCards.vue'
@@ -336,6 +333,7 @@ const {
 	folderCounts,
 	selectedAssets,
 	hasMore,
+	loadingMore,
 	searchInput,
 	category,
 	tag,
@@ -355,6 +353,9 @@ const {
 	reloadAll,
 	loadMore,
 } = browser
+
+const sentinel = ref<HTMLElement | null>(null)
+useInfiniteScroll(sentinel, loadingMore, () => hasMore.value, loadMore)
 const {
 	createFolderOpen,
 	renameFolderOpen,


### PR DESCRIPTION
Replace the "Load more" button on the project/folder view with scroll-driven loading. The grid now fetches assets a page at a time and appends them as an IntersectionObserver sentinel nears the viewport; a skeleton row shows only while a page fetch is in flight. Mutation/realtime/poll refreshes re-pull just the rows already loaded so scroll position holds.

Thumbnails in the grid and list views get loading="lazy" + decoding="async" so off-screen images no longer download up front.


Claude-Session: https://claude.ai/code/session_01X3AbSPmfhePLsKb2FC6HXe